### PR TITLE
Use workspaces instead of txt datacards

### DIFF
--- a/combine/nuisance_impacts.sh
+++ b/combine/nuisance_impacts.sh
@@ -4,7 +4,6 @@ ERA=$1
 
 source utils/setup_cmssw.sh
 
-text2workspace.py -m 125 ${ERA}_datacard.txt -o ${ERA}_workspace.root
 combineTool.py -M Impacts -m 125 -d ${ERA}_workspace.root --doInitialFit
 combineTool.py -M Impacts -m 125 -d ${ERA}_workspace.root --doFits --parallel 20
 combineTool.py -M Impacts -m 125 -d ${ERA}_workspace.root --output ${ERA}_impacts.json

--- a/combine/prefit_postfit_shapes.sh
+++ b/combine/prefit_postfit_shapes.sh
@@ -5,8 +5,8 @@ ERA=$1
 source utils/setup_cmssw.sh
 
 # Prefit shapes
-PostFitShapes -m 125 -d ${ERA}_datacard.txt -o ${ERA}_datacard_shapes_prefit.root
+PostFitShapesFromWorkspace -m 125 -w ${ERA}_workspace.root -o ${ERA}_datacard_shapes_prefit.root
 
 # Postfit shapes
-PostFitShapes -m 125 -d ${ERA}_datacard.txt -o ${ERA}_datacard_shapes_postfit_sb.root -f mlfit${ERA}.root:fit_s --postfit
-PostFitShapes -m 125 -d ${ERA}_datacard.txt -o ${ERA}_datacard_shapes_postfit_b.root -f mlfit${ERA}.root:fit_b --postfit
+PostFitShapesFromWorkspace -m 125 -w ${ERA}_workspace.root -o ${ERA}_datacard_shapes_postfit_sb.root -f mlfit${ERA}.root:fit_s --postfit
+PostFitShapesFromWorkspace -m 125 -w ${ERA}_workspace.root -o ${ERA}_datacard_shapes_postfit_b.root -f mlfit${ERA}.root:fit_b --postfit

--- a/combine/prefit_shapes.sh
+++ b/combine/prefit_shapes.sh
@@ -5,4 +5,4 @@ ERA=$1
 source utils/setup_cmssw.sh
 
 # Prefit shapes
-PostFitShapes -m 125 -d ${ERA}_datacard.txt -o ${ERA}_datacard_shapes_prefit.root
+PostFitShapesFromWorkspace -m 125 -w ${ERA}_workspace.root -o ${ERA}_datacard_shapes_prefit.root

--- a/combine/signal_strength.sh
+++ b/combine/signal_strength.sh
@@ -8,7 +8,7 @@ source utils/setup_cmssw.sh
 if [ $STXS_SIGNALS == 0 ]
 then
     # Fit
-    combine -M MaxLikelihoodFit -m 125 ${ERA}_datacard.txt --robustFit 1 -n $ERA
+    combine -M MaxLikelihoodFit -m 125 ${ERA}_workspace.root --robustFit 1 -n $ERA
 fi
 
 if [ $STXS_SIGNALS == 1 ]
@@ -17,7 +17,7 @@ then
     combineTool.py \
         -M T2W \
         -m 125 \
-        -o ${ERA}_workspace.root \
+        -o ${ERA}_workspace_STXS_stage1.root \
         -P HiggsAnalysis.CombinedLimit.PhysicsModel:multiSignalModel \
         --PO '"map=^.*/ggH125_0J.?$:r_ggH_0J[1,-30,30]"' \
         --PO '"map=^.*/ggH125_1J.?$:r_ggH_1J[1,-30,30]"' \
@@ -27,8 +27,8 @@ then
         --PO '"map=^.*/qqH125_VBFTOPO_JET3.?$:r_qqH_VBFTOPO_JET3[1,-30,30]"' \
         --PO '"map=^.*/qqH125_REST.?$:r_qqH_REST[1,-30,30]"' \
         --PO '"map=^.*/qqH125_PTJET1_GT200.?$:r_qqH_PTJET1_GT200[1,-30,30]"' \
-        -i ${ERA}_datacard.txt
+        -i ${ERA}_workspace.root
 
     # Fit
-    combineTool.py -M MultiDimFit -m 125 -d ${ERA}_workspace.root --algo singles --robustFit 1 -n $ERA
+    combineTool.py -M MultiDimFit -m 125 -d ${ERA}_workspace_STXS_stage1.root --algo singles --robustFit 1 -n $ERA
 fi

--- a/combine/significance.sh
+++ b/combine/significance.sh
@@ -4,4 +4,4 @@ ERA=$1
 
 source utils/setup_cmssw.sh
 
-combine -M ProfileLikelihood -t -1 --expectSignal 1 --toysFrequentist --significance -m 125 -n $ERA ${ERA}_datacard.txt
+combine -M ProfileLikelihood -t -1 --expectSignal 1 --toysFrequentist --significance -m 125 -n $ERA ${ERA}_workspace.root

--- a/datacards/produce_datacard.sh
+++ b/datacards/produce_datacard.sh
@@ -8,9 +8,30 @@ STXS_SIGNALS=$2
 STXS_CATEGORIES=$3
 CHANNELS=${@:4}
 
-python datacards/produce_datacard.py \
-    --era $ERA \
-    --channels $CHANNELS \
-    --stxs-signals $STXS_SIGNALS \
-    --stxs-categories $STXS_CATEGORIES \
-    --shapes ${ERA}_shapes.root
+USE_DATACARDPRODUCER=1
+if [ -n "$USE_DATACARDPRODUCER" ]; then
+    python datacards/produce_datacard.py \
+        --era $ERA \
+        --channels $CHANNELS \
+        --stxs-signals $STXS_SIGNALS \
+        --stxs-categories $STXS_CATEGORIES \
+        --shapes ${ERA}_shapes.root
+
+    combineTool.py -M T2W -o ${ERA}_workspace.root -i ${ERA}_datacard.txt -m 125.0 --parallel 8
+fi
+
+#USE_COMBINEHARVESTER=1
+if [ -n "$USE_COMBINEHARVESTER" ]; then
+    CMSSW_7_4_7/bin/slc6_amd64_gcc491/MorphingSM2017 \
+        --input_folder_mt="../../../../.." \
+        --input_folder_et="../../../../.." \
+        --input_folder_tt="../../../../.." \
+        --real_data=false \
+        --jetfakes=false \
+        --postfix="-ML" \
+        --channel="mt" \
+        --auto_rebin=true \
+        --output="smhtt"
+
+    combineTool.py -M T2W -o ${ERA}_workspace.root -i output/smhtt/cmb/125/*.txt --parallel 8
+fi

--- a/utils/init_cmssw.sh
+++ b/utils/init_cmssw.sh
@@ -1,14 +1,24 @@
 #!/bin/bash
 
+# Export CMSSW
 export SCRAM_ARCH=slc6_amd64_gcc491
 export VO_CMS_SW_DIR=/cvmfs/cms.cern.ch
 source $VO_CMS_SW_DIR/cmsset_default.sh
 
-scramv1 project CMSSW CMSSW_7_4_7
+scram project CMSSW CMSSW_7_4_7
 cd CMSSW_7_4_7/src
 
-git clone https://github.com/cms-analysis/HiggsAnalysis-CombinedLimit.git HiggsAnalysis/CombinedLimit -b 74x-root6
-git clone https://github.com/cms-analysis/CombineHarvester.git CombineHarvester -b analysis-HIG-16-006-freeze-080416
+# Clone combine
+git clone https://github.com/cms-analysis/HiggsAnalysis-CombinedLimit HiggsAnalysis/CombinedLimit
+cd HiggsAnalysis/CombinedLimit
+git fetch origin
+git checkout v6.3.2
+cd ../..
 
-scramv1 b -j 24
-scramv1 b python
+# Clone CombineHarvester
+git clone https://github.com/cms-analysis/CombineHarvester CombineHarvester -b SMHTT2017-dev
+mkdir -p CombineHarvester/HTTSM2017/shapes
+
+# Build
+scram b -j 24
+scram b python


### PR DESCRIPTION
- Benutzt workspaces zum fitten und erstellt diese auch beim datacard produzieren. Wird fuer das CombineHarvester repo spaeter gebraucht.
- Bereitet das Fitten mit dem CombineHarvester repo vor.