### PR TITLE
add year 2016/2017 to plots

### DIFF
--- a/plotting/plot_shapes.py
+++ b/plotting/plot_shapes.py
@@ -369,9 +369,9 @@ def main(args):
             # draw additional labels
             plot.DrawCMS()
             if "2016" in args.era:
-                plot.DrawLumi("35.9 fb^{-1} (13 TeV)")
+                plot.DrawLumi("35.9 fb^{-1} (2016, 13 TeV)")
             elif "2017" in args.era:
-                plot.DrawLumi("41.3 fb^{-1} (13 TeV)")
+                plot.DrawLumi("41.3 fb^{-1} (2017, 13 TeV)")
             else:
                 logger.critical("Era {} is not implemented.".format(args.era))
                 raise Exception


### PR DESCRIPTION
Sollen wir das Jahr zu den Plots hinzufuegen? Ich finde es dann klarer um 2016/2017 zu trennen (weil die lumi ist schon sehr aehnlich). Oder interferiert das mit dem CMS Style?

Meinungen?

So sieht's dann aus:
![x](https://user-images.githubusercontent.com/6951222/45921589-eaf53b00-beb8-11e8-90d6-7e5e8251cdcf.png)
